### PR TITLE
AOS-6574: Oppgraderte til spring boot 2.6.6. Fjernet eksplisitt avhen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@ Alle viktige endringer i dette prosjektet vil bli dokumentert i denne filen.
 
 Formatet i denne filen er basert på Keep a Changelog og prosjektet følger Semantic Versioning.
 
-[1.3.6] - 2022-03-31
+[1.3.6] - 2022-04-01
 Changed
-Slettet ZipkinIntegrationTest, slo av javadoc check, oppgraderte maven-dependency-plugin.
+Oppgraderte til SpringBoot versjon 2.6.6.
+Oppgraderte versjon av aurora-spring-boot-base-starter versjon 1.3.9.
 
 [1.3.5] - 2022-03-29
 Changed
 Oppgraderte til SpringBoot versjon 2.6.5.
 Oppgraderte versjon av aurora-spring-boot-base-starter versjon 1.3.7.
+Slettet ZipkinIntegrationTest, slo av javadoc check, oppgraderte maven-dependency-plugin.
 
 Added
 CHANGELOG.md for å dokumentere endringer.

--- a/webflux-starter/pom.xml
+++ b/webflux-starter/pom.xml
@@ -19,8 +19,8 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <basestarter.version>1.3.7</basestarter.version>
-    <springboot.version>2.6.5</springboot.version>
+    <basestarter.version>1.3.9</basestarter.version>
+    <springboot.version>2.6.6</springboot.version>
     <springcloud.release.train.version>2021.0.1</springcloud.release.train.version>
     <kotlin.version>1.6.10</kotlin.version>
     <kotlin.code.style>official</kotlin.code.style>
@@ -92,16 +92,6 @@
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <!-- TODO: Fjern denne dependencyen når spring boot inkluderer versjon av com.fasterxml.jackson.core : jackson-databind -->
-      <!--     som ikke inneholder sårbarhet (CVE-2020-36518). -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.13.2.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Oppgraderte til spring boot 2.6.6. Fjernet eksplisitt avhengighet til jackson-databind.